### PR TITLE
Fix jquery ui datepicker with conditional lazyloading

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,300,700' rel='stylesheet' type='text/css'>
 
     <link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
-    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css">
     <link type="text/css" rel="stylesheet" href="styles/main.css">
 
     <!--[if lt IE 9]>
@@ -575,8 +574,8 @@
         <li class="available-times__row">
             <div class="form-group">
                 <label for="{{type}}Date{{id}}">Date</label>
-                <input class="form-input input--date" type="date" id="{{type}}Date{{id}}" required> 
-                <input type="hidden" class="input-formatted-date" name="{{type}}Date" id="alt-{{type}}Date{{id}}">
+                <input class="form-input input--date" type="date" name="{{type}}Date" id="{{type}}Date{{id}}" required> 
+                <input type="hidden" class="input-formatted-date" id="alt-{{type}}Date{{id}}">
                 <div class="help-block with-errors"></div>
             </div>
             <div class="form-group">
@@ -594,8 +593,6 @@
     </script>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-    <script src="scripts/jquery-ui.min.js"></script> 
-    <script src="scripts/jquery-ui-i18n.min.js"></script> 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/salvattore/1.0.9/salvattore.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.5/validator.min.js"></script>
     <script src="scripts/main.js"></script>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -153,6 +153,7 @@ $(function(){
             function addRow(hideDeleteButton) {
                 var $row = $(rowTemplate.replace(/{{type}}/g, type).replace(/{{id}}/g, rowID++));
 
+                // Set a minimum value for the date input to today's date
                 $row.find('.input--date').attr('min', yyyymmdd());
 
                 if (!Modernizr.inputtypes.date){
@@ -160,12 +161,15 @@ $(function(){
                 }
 
                 if (!hideDeleteButton) {
+                    // Make the new row's value equal to the previous row 
+                    // if one already exists, to save users time
                     var $prevRow = $self.find('.available-times__row').last();
                     datetimeClasses.forEach(function(c){
                         var prevVal = $prevRow.find(c).val();
                         $row.find(c).val(prevVal).trigger('update');
                     });
                 } else {
+                    // Remove the 'X' icon if there's only one row
                     $row.find('.remove-time').hide();
                 }
 


### PR DESCRIPTION
Hey @pavsaiprasad, I think I've got a fix for that jQuery UI lazyloading issue. Can you please let me know whether this works? Basically, I used `$.when` to wait for both of those JS libraries to download before initialising the datepicker listener.

I've also restored some useful functionality that you deleted. I should've commented it properly so it'd be obvious what it does.

I've also changed uses of `checkInputSupport('date')` back to `Modernizr.inputtypes.date`. I like your instinct there, and your approach is definitely cleaner. However that checkInputSupport function looks a little too processor-intensive to me (it creates and then tests a DOM element), so I'd rather only have to do it once then check the result, rather than rerun it many times every time we create a new row.